### PR TITLE
Added boxShadow attribute to DevicePage to add a shadow to bottom nav.

### DIFF
--- a/src/DevicePage.js
+++ b/src/DevicePage.js
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
         position: 'fixed',
         width: '100%',
         bottom: 0,
-        boxShadow: "16px -1px 28px rgba(0,0,0,0.25)",
+        boxShadow: "0px 1px 10px 0px rgba(0,0,0,0.12)",
         [theme.breakpoints.up('md')]: {
             width: `calc(100% - ${drawerWidth}px)`,
         },

--- a/src/DevicePage.js
+++ b/src/DevicePage.js
@@ -19,6 +19,7 @@ const useStyles = makeStyles((theme) => ({
         position: 'fixed',
         width: '100%',
         bottom: 0,
+        boxShadow: "16px -1px 28px rgba(0,0,0,0.25)",
         [theme.breakpoints.up('md')]: {
             width: `calc(100% - ${drawerWidth}px)`,
         },


### PR DESCRIPTION
Addressed issue [14](https://github.com/airpartners/aq-web-client/issues/14) by adding a boxShadow attribute to the styles section associated with the bottom navigation bar on DevicePage so that the layer height of the bottom navigation bar is self evident. I decided to use a 1px width on the bar to try to match the top gutter, but I am open to making changes if others prefer other widths.

Here's a screenshot with the new boxShadow: https://gyazo.com/e8edf08d6e22816301c0dfcffc904dc7.
Here's one with 2px boxShadow, which I decided against in favor of 1px: https://gyazo.com/bcfe37a8e056fd0416bfd97c5c02327a