### PR TITLE
Changed PNC learn more questions to say PNC instead of NO

### DIFF
--- a/src/Translations.js
+++ b/src/Translations.js
@@ -175,8 +175,8 @@ export const en = {
         },
         "PNC": {
             "Questions": {
-                "What is it": "What is Nitrogen Oxides and what produces it?",
-                "Harmful effects": "What kinds of harmful effects can Nitrogen Oxides cause?",
+                "What is it": "What is Particle Number Concentration and what produces it?",
+                "Harmful effects": "What kinds of harmful effects can Particle Number Concentration cause?",
                 "At risk populations": "",
                 "Sources": "Sources",
             },


### PR DESCRIPTION
The "Learn More" questions for PNC say "nitrogen oxide" instead of PNC (see issue [36](https://github.com/airpartners/aq-web-client/issues/36)). This fix doesn't change the wording at all (which miight be worth investigating separately). but it does change the title to state the current particle name instead.