### PR TITLE
pollutant bar responsive adjustment

### DIFF
--- a/src/PollutantBarComponent.js
+++ b/src/PollutantBarComponent.js
@@ -15,7 +15,6 @@ const useStyles = makeStyles((theme) => ({
     content: {
         display: "flex",
         width: "100%",
-        maxWidth: "500px",
         flexDirection: "column",
         marginBottom: "1.5rem",
     },


### PR DESCRIPTION
<img width="1556" alt="Picture of air quality data present in bar plots" src="https://user-images.githubusercontent.com/4595970/109598392-39c24880-7ae7-11eb-8c2e-f688d41e92fa.png">

Improve the responsiveness of the bars. I checked and the filled elements scale proportionally, so this should be ok.