### PR TITLE
Swap maps API key with updated key

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Run Tests
         env:
           CI: true
+          REACT_APP_MAPS_KEY: ${{ secrets.REACT_APP_MAPS_KEY }}
         run: npm test
       - name: Build
-        # only included to catch lint errors, should be udpated later to just do that rather than build the whole thing to save time
+        # only included to catch lint errors, should be updated later to just do that rather than build the whole thing to save time
         run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Run Tests
         env:
           CI: true
+          REACT_APP_MAPS_KEY: ${{ secrets.REACT_APP_MAPS_KEY }}
         run: npm test
       - name: Build
         run: npm run build
@@ -45,3 +46,4 @@ jobs:
           args: deploy --only hosting
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          REACT_APP_MAPS_KEY: ${{ secrets.REACT_APP_MAPS_KEY }}

--- a/src/DeviceMap.js
+++ b/src/DeviceMap.js
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
     }
 }));
 
-const mapApiKey = 'AIzaSyCE7xH50-i4RcG5HygoL1SKXi3dLbstQtI';
+const mapApiKey = process.env.REACT_APP_MAPS_KEY;
 
 /**
  * Check if a device has geo data.


### PR DESCRIPTION
Fix issue where the old google maps api key (a public browser key) was deactivated by google (for some reason). Generated a new key, and update build process to include dynamic key instead of hardcoded key.

I put the new key is in a github secret to avoid key scraping on public GitHub repo, and updated CI build process to include key in build.

The key is accessible in the Google credential manager.